### PR TITLE
bug: make sure template field can use camelCase

### DIFF
--- a/action/helpers.go
+++ b/action/helpers.go
@@ -44,7 +44,7 @@ func listNodeFields(node parse.Node, res []TemplateField) []TemplateField {
 }
 
 func NewField (node string) TemplateField {
-	re := regexp.MustCompile(`^{{(?:default\s+([^\s]+)\s+)?\.([a-z0-9]+)}}$`)
+	re := regexp.MustCompile(`^{{(?:default\s+([^\s]+)\s+)?\.([a-zA-Z0-9]+)}}$`)
 
 	submatches := re.FindStringSubmatch(node)
 

--- a/action/helpers.go
+++ b/action/helpers.go
@@ -1,6 +1,9 @@
 package action
 
 import (
+	"errors"
+	"fmt"
+	"log"
 	"regexp"
 	"strings"
 	"text/template"
@@ -20,7 +23,11 @@ func ListTemplateFields(t *template.Template) []TemplateField {
 func listNodeFields(node parse.Node, res []TemplateField) []TemplateField {
 	if node.Type() == parse.NodeAction {
 
-		field := NewField(node.String())
+		field, err := NewField(node.String())
+		if err != nil {
+			log.Printf("Error: %s. Skipping node %s", err, node.String())
+			return res
+		}
 
 		add := true
 		for _, v := range res {
@@ -43,14 +50,18 @@ func listNodeFields(node parse.Node, res []TemplateField) []TemplateField {
 	return res
 }
 
-func NewField (node string) TemplateField {
+func NewField (node string) (TemplateField, error) {
 	re := regexp.MustCompile(`^{{(?:default\s+([^\s]+)\s+)?\.([a-zA-Z0-9]+)}}$`)
 
 	submatches := re.FindStringSubmatch(node)
+	if submatches == nil {
+		err := errors.New(fmt.Sprintf("No match found for string %s", node))
+		return TemplateField{}, err
+	}
 
 	return TemplateField{
 		Name: submatches[2],
 		Default: strings.Trim(submatches[1], "\""),
 		Optional: submatches[1] != "",
-	}
+	}, nil
 }

--- a/action/helpers_test.go
+++ b/action/helpers_test.go
@@ -29,3 +29,13 @@ func TestListNodeField(t *testing.T) {
 		}
 	}
 }
+
+func TestNewFieldAcceptedFormat(t *testing.T) {
+	correctFieldFormat := []string{"{{default \"0.1\" .lowercase}}", "{{default \"0.1\" .lowercase123}}", "{{default \"0.1\" .camelCase}}", "{{default \"0.1\" .camelCase123}}"}
+	for _, s := range correctFieldFormat {
+		_, err := NewField(s)
+		if err != nil {
+			t.Errorf("Field '%s' should not return an error. Got error '%s'", s, err)
+		}
+	}
+}


### PR DESCRIPTION
Allow fields such as .myFieldHere to be used in the ops template.