### PR TITLE
Gère les erreurs quand on ne peut pas fetcher la liste des apps

### DIFF
--- a/action/apps_list.go
+++ b/action/apps_list.go
@@ -51,7 +51,12 @@ func Run(filters AppFilters) error {
 		ClientSet:      GetClientSet(GetKubeConfigPath()),
 	}
 	currentContext := clientSet.Cluster
-	listApps, _ := ListApps(clientSet.ClientSet)
+	listApps, err := ListApps(clientSet.ClientSet)
+
+	if err != nil {
+		return err
+	}
+
 	mapApps := sortApps(listApps, currentContext)
 
 	//Actual listing

--- a/action/apps_run.go
+++ b/action/apps_run.go
@@ -66,7 +66,12 @@ func (c *AppsRun) Run() error {
 		ClientSet:      GetClientSet(GetKubeConfigPath()),
 	}
 	currentContext := clientSet.Cluster
-	listApps, _ := ListApps(clientSet.ClientSet)
+	listApps, err := ListApps(clientSet.ClientSet)
+
+	if err != nil {
+		return err
+	}
+
 	mapApps := sortApps(listApps, currentContext)
 
 	configMap, err := getConfigMap(c.Application, mapApps)
@@ -278,7 +283,7 @@ func waitPod(currentApp App, jobContext *JobContext) error {
 		time.Sleep(5 * time.Second)
 		tries += 1
 	}
-	
+
 	fmt.Println()
 
 	return nil


### PR DESCRIPTION
Dans certains cas, richman n'était pas capable de lire la liste des apps pour une cause externe : timeout, pas sur le VPN, etc. L'erreur était ignoré et le nil retourné par la valeur était passé à une fonction de tri, qui plantait avec un nil access.

Avec l'ajout de la gestion d'erreur, un message clair est affiché dans la console qui explique le problème, et l'application n'explose plus avec une stack trace.

*Tests*
- [x] Lister les apps sur le VPN et sans le VPN, et s'assurer que le message d'erreur est correctement affiché si pas sur le VPN