### PR TITLE
DOPS-3388 : Add parameter namespace to listApps function

### DIFF
--- a/action/apps_list.go
+++ b/action/apps_list.go
@@ -51,7 +51,11 @@ func Run(filters AppFilters) error {
 		ClientSet:      GetClientSet(GetKubeConfigPath()),
 	}
 	currentContext := clientSet.Cluster
-	listApps, err := ListApps(clientSet.ClientSet)
+	var namespace string = ""
+	if len(filters.Filters) > 0 {
+		namespace = filters.Filters[0]
+	}
+	listApps, err := ListApps(clientSet.ClientSet, namespace)
 
 	if err != nil {
 		return err
@@ -146,8 +150,8 @@ func ConnectCluster() *kubernetes.Clientset {
 }
 
 //Return a pointer to a list of Pods
-func ListApps(clientSet kubernetes.Interface) (*v1.PodList, error) {
-	pods, err := clientSet.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
+func ListApps(clientSet kubernetes.Interface, namespace string) (*v1.PodList, error) {
+	pods, err := clientSet.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/action/apps_run.go
+++ b/action/apps_run.go
@@ -66,7 +66,7 @@ func (c *AppsRun) Run() error {
 		ClientSet:      GetClientSet(GetKubeConfigPath()),
 	}
 	currentContext := clientSet.Cluster
-	listApps, err := ListApps(clientSet.ClientSet)
+	listApps, err := ListApps(clientSet.ClientSet, c.Application)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description 
La function listApps qui est appelle quand on execute la commande `richman apps run -a equisoft-connect -c cpu="0.2" -c memory="256M"` liste les pods dans tous les namespaces. 
Puisque les ops n'ont le droit de lister les pods que dans le namespace `equisoft-connect` et `equisoft-plan`, on a un forbidden. 
Ce fix vient ajouter le namespace de l'application a la function qui liste les pods. 